### PR TITLE
Fix error message from Salt 2017.7

### DIFF
--- a/SaltGenResource.py
+++ b/SaltGenResource.py
@@ -153,7 +153,7 @@ class ResourceGenerator(SaltNodesCommandParser):
         mine = caller.cmd(
             'mine.get', self.config['tgt'],
             self.options.mine_function,
-            expr_form=self.config['selected_target_option'],
+            tgt_type=self.config['selected_target_option'],
             exclude_minion=self.options.include_server_node)
 
         # Special handling for server node

--- a/SaltGenResource.py
+++ b/SaltGenResource.py
@@ -3,6 +3,7 @@
 import salt.client
 import salt.utils
 import salt.grains
+import salt.version
 import salt.utils.parsers
 import salt.ext.six as six
 import salt.syspaths as syspaths
@@ -146,15 +147,23 @@ class ResourceGenerator(SaltNodesCommandParser):
     def run(self):
         resources = {}
 
+        # Create a Salt Caller object
         caller = salt.client.Caller(
             os.path.join(self.options.config_dir, self._config_filename_))
 
+        # Account for an API change in Salt Nitrogen (2017.7)
+        kwargs = {'exclude_minion': self.options.include_server_node}
+        if salt.version.__saltstack_version__ >= salt.version.SaltStackVersion.from_name('Nitrogen'):
+            kwargs['tgt_type'] = self.config['selected_target_option']
+        else:
+            kwargs['expr_form'] = self.config['selected_target_option']
+
         # Call Salt Mine to retrieve grains for all nodes
         mine = caller.cmd(
-            'mine.get', self.config['tgt'],
+            'mine.get',
+            self.config['tgt'],
             self.options.mine_function,
-            tgt_type=self.config['selected_target_option'],
-            exclude_minion=self.options.include_server_node)
+            **kwargs)
 
         # Special handling for server node
         if self.options.include_server_node:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,23 +3,51 @@
 
 Vagrant.configure("2") do |config|
 
-  config.vm.box = "bento/ubuntu-16.04"
-  config.vm.box_check_update = false
+  # Define a VM to test Salt 2016.11
+  config.vm.define "carbon" do |carbon|
+    carbon.vm.box = "bento/ubuntu-16.04"
+    carbon.vm.box_check_update = false
 
-  config.vm.provision :salt do |salt|
-    salt.install_master = true
-    salt.install_type = "stable"
-    salt.minion_config = "config/minion"
-    salt.master_config = "config/master"
-    salt.verbose = false
+    carbon.vm.provision :salt do |salt|
+      salt.install_master = true
+      salt.install_type = "git"
+      salt.install_args = "v2016.11.6"
+      salt.minion_config = "config/minion"
+      salt.master_config = "config/master"
+      salt.verbose = false
+    end
+
+    carbon.vm.provision :shell do |test|
+      test.name = "run tests"
+      test.inline = <<-SHELL
+        salt-call -l quiet mine.update True
+        python2 "/vagrant/test.py"
+      SHELL
+    end
+
   end
 
-  config.vm.provision :shell do |test|
-    test.name = "run tests"
-    test.inline = <<-SHELL
-      salt-call -l quiet mine.update True
-      python2 "/vagrant/test.py"
-    SHELL
+  # Define a VM to test Salt 2017.7
+  config.vm.define "nitrogen" do |nitrogen|
+    nitrogen.vm.box = "bento/ubuntu-16.04"
+    nitrogen.vm.box_check_update = false
+
+    nitrogen.vm.provision :salt do |salt|
+      salt.install_master = true
+      salt.install_type = "git"
+      salt.install_args = "v2017.7.0"
+      salt.minion_config = "config/minion"
+      salt.master_config = "config/master"
+      salt.verbose = false
+    end
+
+    nitrogen.vm.provision :shell do |test|
+      test.name = "run tests"
+      test.inline = <<-SHELL
+        salt-call -l quiet mine.update True
+        python2 "/vagrant/test.py"
+      SHELL
+    end
   end
 
 end


### PR DESCRIPTION
After upgrading to Salt 2017.7, this script returns an error message
from Salt about using "tgt_type" over "expr_form".  Changing this
appears to break nothing and the script works as expected.