### PR TITLE
tags are not created

### DIFF
--- a/SaltGenResource.py
+++ b/SaltGenResource.py
@@ -399,6 +399,7 @@ class ResourceGenerator(object):
         tags = set()
         value = datautils.traverse_dict_and_list(
             grains, item, default=None, delimiter=self.options.delimiter)
+        value = value[0]
         if value is None:
             pass
         elif not value:


### PR DESCRIPTION
This is the command I'm using:
`./SaltGenResource.py -a environment,region,roles -t roles,environment,region -G environment:STG`

received the following warnings:
```
[WARNING ] Requested grain 'roles' is not available on minion: nl1-stgjob03
[WARNING ] Requested grain 'environment' is not available on minion: nl1-stgjob03
[WARNING ] Requested grain 'region' is not available on minion: nl1-stgjob03

```
Even though they exists and attributes are created properly:
```
nl1-stgjob03:
  IP: 1.1.1.1
  environment: STG
  hostname: nl1-stgjob03
  region: NL
  roles: job

```

```
[root@master]# salt 'nl1-stgjob03' grains.get roles
nl1-stgjob03:
    - job
[root@master scripts]# salt 'nl1-stgjob03' grains.get region
nl1-stgjob03:
    - NL
[root@master scripts]# salt 'nl1-stgjob03' grains.get environment
nl1-stgjob03:
    - STG
```



Output after the fix:
```
nl1-stgjob03:
  IP: 1.1.1.1
  environment: STG
  hostname: nl1-stgjob03
  region: NL
  roles: job
  tags:
  - STG
  - job
  - NL

```